### PR TITLE
fix filtered semantic search ranking

### DIFF
--- a/py/core/providers/database/chunks.py
+++ b/py/core/providers/database/chunks.py
@@ -342,8 +342,16 @@ class PostgresChunksHandler(Handler):
             f"{table_name}.collection_ids",
             f"{table_name}.text",
         ]
+        filtered_cols = [
+            "id",
+            "document_id",
+            "owner_id",
+            "collection_ids",
+            "text",
+        ]
 
         params: list[str | int | bytes] = []
+        has_filters = bool(search_settings.filters)
 
         # For binary vectors (INT1), implement two-stage search
         if self.quantization_type == VectorQuantizationType.INT1:
@@ -374,10 +382,16 @@ class PostgresChunksHandler(Handler):
             cols.append(
                 f"{table_name}.vec"
             )  # Need original vector for re-ranking
+            filtered_cols.append("vec")
             if search_settings.include_metadatas:
                 cols.append(f"{table_name}.metadata")
+                filtered_cols.append("metadata")
 
             select_clause = ", ".join(cols)
+            filtered_select_clause = ", ".join(filtered_cols)
+            filtered_stage1_select_clause = (
+                f"{select_clause}, {table_name}.vec_binary"
+            )
             where_clause = ""
             params.append(stage1_param)
 
@@ -391,29 +405,57 @@ class PostgresChunksHandler(Handler):
             )
 
             # First stage: Get candidates using binary search
-            query = f"""
-            WITH candidates AS (
-                SELECT {select_clause},
-                    ({stage1_distance}) as binary_distance
-                FROM {table_name}
-                {where_clause}
-                ORDER BY {stage1_distance}
-                LIMIT ${len(params) + 1}
-                OFFSET ${len(params) + 2}
-            )
-            -- Second stage: Re-rank using original vectors
-            SELECT
-                id,
-                document_id,
-                owner_id,
-                collection_ids,
-                text,
-                {"metadata," if search_settings.include_metadatas else ""}
-                (vec <=> ${len(params) + 4}::vector{vector_dim}) as distance
-            FROM candidates
-            ORDER BY distance
-            LIMIT ${len(params) + 3}
-            """
+            if has_filters:
+                query = f"""
+                WITH filtered AS MATERIALIZED (
+                    SELECT {filtered_stage1_select_clause}
+                    FROM {table_name}
+                    {where_clause}
+                ),
+                candidates AS (
+                    SELECT *,
+                        (vec_binary {binary_search_measure_repr} $1::bit{bit_dim}) as binary_distance
+                    FROM filtered
+                    ORDER BY vec_binary {binary_search_measure_repr} $1::bit{bit_dim}
+                    LIMIT ${len(params) + 1}
+                    OFFSET ${len(params) + 2}
+                )
+                -- Second stage: Re-rank using original vectors
+                SELECT
+                    id,
+                    document_id,
+                    owner_id,
+                    collection_ids,
+                    text,
+                    {"metadata," if search_settings.include_metadatas else ""}
+                    (vec <=> ${len(params) + 4}::vector{vector_dim}) as distance
+                FROM candidates
+                ORDER BY distance
+                LIMIT ${len(params) + 3}
+                """
+            else:
+                query = f"""
+                WITH candidates AS (
+                    SELECT {select_clause},
+                        ({stage1_distance}) as binary_distance
+                    FROM {table_name}
+                    ORDER BY {stage1_distance}
+                    LIMIT ${len(params) + 1}
+                    OFFSET ${len(params) + 2}
+                )
+                -- Second stage: Re-rank using original vectors
+                SELECT
+                    id,
+                    document_id,
+                    owner_id,
+                    collection_ids,
+                    text,
+                    {"metadata," if search_settings.include_metadatas else ""}
+                    (vec <=> ${len(params) + 4}::vector{vector_dim}) as distance
+                FROM candidates
+                ORDER BY distance
+                LIMIT ${len(params) + 3}
+                """
 
             params.extend(
                 [
@@ -431,13 +473,19 @@ class PostgresChunksHandler(Handler):
             )
             distance_calc = f"{table_name}.vec {search_settings.chunk_settings.index_measure.pgvector_repr} $1::vector{vector_dim}"
             query_param = str(query_vector)
+            filtered_inner_cols = filtered_cols + ["vec"]
+            filtered_outer_cols = filtered_cols.copy()
 
             if search_settings.include_scores:
                 cols.append(f"({distance_calc}) AS distance")
             if search_settings.include_metadatas:
                 cols.append(f"{table_name}.metadata")
+                filtered_inner_cols.append("metadata")
+                filtered_outer_cols.append("metadata")
 
             select_clause = ", ".join(cols)
+            filtered_inner_select_clause = ", ".join(filtered_inner_cols)
+            filtered_outer_select_clause = ", ".join(filtered_outer_cols)
             where_clause = ""
             params.append(query_param)
 
@@ -449,14 +497,33 @@ class PostgresChunksHandler(Handler):
                 )
                 params = new_params
 
-            query = f"""
-            SELECT {select_clause}
-            FROM {table_name}
-            {where_clause}
-            ORDER BY {distance_calc}
-            LIMIT ${len(params) + 1}
-            OFFSET ${len(params) + 2}
-            """
+            if has_filters:
+                outer_select_clause = filtered_outer_select_clause
+                if search_settings.include_scores:
+                    outer_select_clause = (
+                        f"{outer_select_clause}, "
+                        f"(vec {search_settings.chunk_settings.index_measure.pgvector_repr} $1::vector{vector_dim}) AS distance"
+                    )
+                query = f"""
+                WITH filtered AS MATERIALIZED (
+                    SELECT {filtered_inner_select_clause}
+                    FROM {table_name}
+                    {where_clause}
+                )
+                SELECT {outer_select_clause}
+                FROM filtered
+                ORDER BY vec {search_settings.chunk_settings.index_measure.pgvector_repr} $1::vector{vector_dim}
+                LIMIT ${len(params) + 1}
+                OFFSET ${len(params) + 2}
+                """
+            else:
+                query = f"""
+                SELECT {select_clause}
+                FROM {table_name}
+                ORDER BY {distance_calc}
+                LIMIT ${len(params) + 1}
+                OFFSET ${len(params) + 2}
+                """
             params.extend([search_settings.limit, search_settings.offset])
         results = await self.connection_manager.fetch_query(query, params)
 

--- a/py/tests/unit/database/test_chunks_handler_semantic_search.py
+++ b/py/tests/unit/database/test_chunks_handler_semantic_search.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.base import SearchSettings, VectorQuantizationType
+from core.providers.database.chunks import PostgresChunksHandler
+from core.providers.database.base import PostgresConnectionManager
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_materializes_filtered_fp32_results():
+    fetch_query = AsyncMock(return_value=[])
+    connection_manager = cast(
+        PostgresConnectionManager,
+        SimpleNamespace(fetch_query=fetch_query),
+    )
+    handler = PostgresChunksHandler(
+        project_name="test_project",
+        connection_manager=connection_manager,
+        dimension=4,
+        quantization_type=VectorQuantizationType.FP32,
+    )
+    settings = SearchSettings(
+        filters={"document_id": {"$in": ["11111111-1111-4111-8111-111111111111"]}},
+        limit=10,
+        offset=0,
+    )
+
+    await handler.semantic_search([0.1, 0.2, 0.3, 0.4], settings)
+
+    assert fetch_query.await_args is not None
+    query = fetch_query.await_args.args[0]
+    assert "WITH filtered AS MATERIALIZED" in query
+    assert "FROM filtered" in query
+    assert "ORDER BY vec <=> $1::vector(4)" in query
+    assert "test_project.chunks.id" not in query.split("FROM filtered", 1)[1]
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_keeps_direct_knn_path_without_filters():
+    fetch_query = AsyncMock(return_value=[])
+    connection_manager = cast(
+        PostgresConnectionManager,
+        SimpleNamespace(fetch_query=fetch_query),
+    )
+    handler = PostgresChunksHandler(
+        project_name="test_project",
+        connection_manager=connection_manager,
+        dimension=4,
+        quantization_type=VectorQuantizationType.FP32,
+    )
+    settings = SearchSettings(limit=10, offset=0)
+
+    await handler.semantic_search([0.1, 0.2, 0.3, 0.4], settings)
+
+    assert fetch_query.await_args is not None
+    query = fetch_query.await_args.args[0]
+    assert "WITH filtered AS MATERIALIZED" not in query
+    assert "FROM filtered" not in query
+    assert "FROM test_project.chunks" in query
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_materializes_filtered_int1_candidates():
+    fetch_query = AsyncMock(return_value=[])
+    connection_manager = cast(
+        PostgresConnectionManager,
+        SimpleNamespace(fetch_query=fetch_query),
+    )
+    handler = PostgresChunksHandler(
+        project_name="test_project",
+        connection_manager=connection_manager,
+        dimension=4,
+        quantization_type=VectorQuantizationType.INT1,
+    )
+    settings = SearchSettings(
+        filters={"document_id": {"$in": ["11111111-1111-4111-8111-111111111111"]}},
+        limit=10,
+        offset=0,
+    )
+
+    await handler.semantic_search([0.1, 0.2, 0.3, 0.4], settings)
+
+    assert fetch_query.await_args is not None
+    query = fetch_query.await_args.args[0]
+    assert "WITH filtered AS MATERIALIZED" in query
+    assert "FROM filtered" in query
+    assert "vec_binary" in query
+    assert "ORDER BY distance" in query


### PR DESCRIPTION
## Summary
- materialize filtered chunk candidates before applying pgvector ordering so semantic search ranks within the permitted document set
- keep the unfiltered fast path unchanged and carry the vector column through the filtered FP32 path so distance ordering still works
- add unit coverage for filtered and unfiltered semantic search query shapes