### PR TITLE
skip chunk quota checks for superusers

### DIFF
--- a/py/core/main/services/ingestion_service.py
+++ b/py/core/main/services/ingestion_service.py
@@ -445,38 +445,38 @@ class IngestionService:
         vector_batch: list[VectorEntry] = []
         document_counts: dict[UUID, int] = {}
 
-        # We'll track usage from the first user we see; if your scenario allows
-        # multiple user owners in a single ingestion, you'd need to refine usage checks.
+        # We track usage from the first owner because an ingestion is expected
+        # to contain chunks for a single owner.
+        owner_id = vector_entries[0].owner_id
+        owner = await self.providers.database.users_handler.get_user_by_id(
+            owner_id
+        )
+
         current_usage = None
-        user_id_for_usage_check: UUID | None = None
-
-        count = 0
-
-        for msg in vector_entries:
-            # If we haven't set usage yet, do so on the first chunk
-            if current_usage is None:
-                user_id_for_usage_check = msg.owner_id
-                usage_data = (
-                    await self.providers.database.chunks_handler.list_chunks(
-                        limit=1,
-                        offset=0,
-                        filters={"owner_id": msg.owner_id},
-                    )
+        max_chunks = None
+        if not owner.is_superuser:
+            usage_data = (
+                await self.providers.database.chunks_handler.list_chunks(
+                    limit=1,
+                    offset=0,
+                    filters={"owner_id": owner_id},
                 )
-                current_usage = usage_data["total_entries"]
-
-            # Figure out the user's limit
-            user = await self.providers.database.users_handler.get_user_by_id(
-                msg.owner_id
             )
+            current_usage = usage_data["total_entries"]
             max_chunks = (
                 self.providers.database.config.app.default_max_chunks_per_user
                 if self.providers.database.config.app
                 else 1e10
             )
-            if user.limits_overrides and "max_chunks" in user.limits_overrides:
-                max_chunks = user.limits_overrides["max_chunks"]
+            if (
+                owner.limits_overrides
+                and "max_chunks" in owner.limits_overrides
+            ):
+                max_chunks = owner.limits_overrides["max_chunks"]
 
+        count = 0
+
+        for msg in vector_entries:
             # Add to our local batch
             vector_batch.append(msg)
             document_counts[msg.document_id] = (
@@ -487,6 +487,7 @@ class IngestionService:
             # Check usage
             if (
                 current_usage is not None
+                and max_chunks is not None
                 and (current_usage + len(vector_batch) + count) > max_chunks
             ):
                 error_message = f"User {msg.owner_id} has exceeded the maximum number of allowed chunks: {max_chunks}"

--- a/py/tests/unit/ingestion/test_ingestion_service.py
+++ b/py/tests/unit/ingestion/test_ingestion_service.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from core.base import Vector, VectorEntry
+from core.base.api.models import User
+from core.main.services.ingestion_service import IngestionService
+
+
+def _make_vector_entry(owner_id):
+    return VectorEntry(
+        id=uuid4(),
+        document_id=uuid4(),
+        owner_id=owner_id,
+        collection_ids=[],
+        vector=Vector(data=[0.1]),
+        text="test chunk",
+        metadata={},
+    )
+
+
+def _make_service(owner, current_usage=0, max_chunks=10_000):
+    chunks_handler = SimpleNamespace(
+        list_chunks=AsyncMock(
+            return_value={"results": [], "total_entries": current_usage}
+        ),
+        upsert_entries=AsyncMock(),
+    )
+    users_handler = SimpleNamespace(
+        get_user_by_id=AsyncMock(return_value=owner)
+    )
+    database = SimpleNamespace(
+        chunks_handler=chunks_handler,
+        users_handler=users_handler,
+        config=SimpleNamespace(
+            app=SimpleNamespace(
+                default_max_chunks_per_user=max_chunks,
+            )
+        ),
+    )
+    providers = SimpleNamespace(database=database)
+    service = IngestionService(config=Mock(), providers=providers)
+    return service, chunks_handler, users_handler
+
+
+@pytest.mark.asyncio
+async def test_store_embeddings_skips_chunk_quota_for_superuser():
+    owner = User(
+        id=uuid4(),
+        email="admin@example.com",
+        is_superuser=True,
+    )
+    vector_entry = _make_vector_entry(owner.id)
+    service, chunks_handler, users_handler = _make_service(
+        owner,
+        current_usage=10_000,
+        max_chunks=1,
+    )
+
+    messages = [
+        message async for message in service.store_embeddings([vector_entry])
+    ]
+
+    users_handler.get_user_by_id.assert_awaited_once_with(owner.id)
+    chunks_handler.list_chunks.assert_not_awaited()
+    chunks_handler.upsert_entries.assert_awaited_once_with([vector_entry])
+    assert messages == [
+        f"Successful ingestion for document_id: {vector_entry.document_id}, "
+        "with vector count: 1"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_store_embeddings_keeps_chunk_quota_for_normal_user():
+    owner = User(
+        id=uuid4(),
+        email="user@example.com",
+        is_superuser=False,
+    )
+    vector_entry = _make_vector_entry(owner.id)
+    service, chunks_handler, users_handler = _make_service(owner)
+
+    messages = [
+        message async for message in service.store_embeddings([vector_entry])
+    ]
+
+    users_handler.get_user_by_id.assert_awaited_once_with(owner.id)
+    chunks_handler.list_chunks.assert_awaited_once_with(
+        limit=1,
+        offset=0,
+        filters={"owner_id": owner.id},
+    )
+    chunks_handler.upsert_entries.assert_awaited_once_with([vector_entry])
+    assert messages == [
+        f"Successful ingestion for document_id: {vector_entry.document_id}, "
+        "with vector count: 1"
+    ]


### PR DESCRIPTION
## Summary

- Skip the per-owner chunk count and chunk-quota comparison when an ingestion owner is a superuser.
- Resolve the owner and quota settings once per ingestion instead of once per chunk.
- Preserve the existing quota and `limits_overrides["max_chunks"]` behavior for normal R2R users.
- Add regression tests proving that superuser ingestion does not call `list_chunks`, while normal-user ingestion still does.

## Exact issue

Monoloom does not use R2R ownership for file permissions. It filters searches with the UUIDs of files and notes that the caller may access. Because Monoloom does not authenticate individual users to R2R, every stored chunk belongs to R2R's default admin user.

The Ruinart database confirmed:

- R2R had one active user, the default admin, and it was a superuser.
- Stored chunks used that superuser as their `owner_id`.
- Each file or note ingestion entered `store_embeddings`, which called `list_chunks(limit=1, filters={"owner_id": ...})` to enforce `default_max_chunks_per_user`.

That call generated query fingerprint `-2001702420117276229`:

```sql
SELECT
    id,
    document_id,
    owner_id,
    collection_ids,
    text,
    metadata,
    COUNT(*) OVER() AS total_entries
FROM r2r_default.chunks
WHERE owner_id = $1
LIMIT $2
OFFSET $3
```

`LIMIT 1` does not make this cheap: PostgreSQL must process all chunks for that owner to calculate `COUNT(*) OVER()`. The query also carries the wide `text` and `metadata` columns through that operation. Since all Monoloom chunks have the same owner, every ingestion counted the entire chunk corpus.

Increasing `default_max_chunks_per_user` would not help because the count query runs before R2R reads and compares the configured limit.

## Incident evidence

This was observed during the [Ruinart 504 incident](https://interloom-io.slack.com/archives/C09V7MFDUGJ/p1785771514631209).

Azure Query Store for 2026-08-03 15:30:14–15:45:14 UTC, which overlaps the incident report at 15:38 UTC, recorded:

- 53 executions of fingerprint `-2001702420117276229`.
- 90.7 seconds average execution time.
- 209.7 seconds maximum execution time.
- About 17.65 million temporary blocks read and the same number written across those executions.

At PostgreSQL's 8 KiB block size, that is approximately 2.54 GiB read and 2.54 GiB written per execution on average, or roughly 5.08 GiB of temporary I/O per quota check.

A nearby 15-minute window recorded 52 executions averaging 147.1 seconds, with a maximum of 239.1 seconds.

The browser polling storm investigated in the Slack thread amplified overall load, but it did not create this SQL. This query came from ingestion-side quota bookkeeping and can recur under concurrent indexing even after polling is reduced.

## Why this fix

R2R's document API already skips its route-level quota preflight for superusers. The ingestion service did not apply the same exemption and still counted every chunk before storing embeddings.

This change makes the ingestion path consistent with the API path:

- Superuser owner: store embeddings without the unused owner-quota count.
- Normal owner: keep the existing count, configured limit, and per-user override behavior.

This does not change Monoloom permissions or R2R access filtering.

## Validation

```text
pytest -q tests/unit/app/test_routes.py tests/unit/app/test_config.py tests/unit/ingestion/test_ingestion_service.py
32 passed, 9 skipped
```

`ruff check`, `ruff format --check`, and `git diff --check` also pass.

## Deployment follow-up

After merging this PR:

1. Build and push a new dated `interloom.azurecr.io/r2r` image.
2. Update Monoloom's pinned R2R image version.
3. Deploy it to Ruinart.
4. Confirm that fingerprint `-2001702420117276229` no longer appears during file or note ingestion.

A separate defense-in-depth improvement can replace the general `COUNT(*) OVER()` implementation with a narrow count query for deployments that use normal R2R user quotas.
